### PR TITLE
Expand YouTube OAuth scopes

### DIFF
--- a/src/youtube_upload.py
+++ b/src/youtube_upload.py
@@ -9,7 +9,10 @@ from googleapiclient.errors import HttpError
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 
-SCOPES: List[str] = ["https://www.googleapis.com/auth/youtube.upload"]
+SCOPES: List[str] = [
+    "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube.readonly",
+]
 
 def _env(name: str, default: Optional[str] = None) -> Optional[str]:
     v = os.getenv(name)


### PR DESCRIPTION
## Summary
- expand the YouTube OAuth scope list to include read-only access in addition to upload permissions

## Testing
- `python -m compileall src` *(fails: SyntaxError: '(' was never closed in src/tts.py:111; pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68c8895420488329857c9dcf7042653f