### PR TITLE
Update YT privacy defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ Optional:
 ## Run
 - Push to `main` or trigger **Actions → yt-auto → Run workflow**.
 - Outputs saved under `out/` and uploaded as artifacts.
+- Optional: set `YT_PRIVACY` to `public`, `unlisted`, or `private` before running the
+  workflow to control the uploaded video's visibility (defaults to `public`).

--- a/src/youtube_upload.py
+++ b/src/youtube_upload.py
@@ -50,7 +50,7 @@ def try_upload_youtube(
     video_path: str,
     title: str,
     description: str,
-    privacy_status: str = "unlisted",
+    privacy_status: str = "public",
     category_id: str = "22",  # People & Blogs (22) / Entertainment (24)
     tags: Optional[List[str]] = None,
 ) -> Optional[str]:


### PR DESCRIPTION
## Summary
- document how to use the optional `YT_PRIVACY` environment variable in the README
- change the default privacy status for uploads to `public` for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c88954aa388329bafccc4940b10af0