### PR TITLE
Normalize and validate YouTube privacy setting

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -238,7 +238,15 @@ def main() -> None:
                     "[upload warning] missing required env vars for YouTube upload: " + reason
                 )
             else:
-                privacy = _env("YT_PRIVACY", "public") or "public"
+                privacy = (_env("YT_PRIVACY", "public") or "public").lower().strip()
+                valid_privacy_values = {"public", "private", "unlisted"}
+                if privacy not in valid_privacy_values:
+                    warn_msg = (
+                        f">> YouTube privacy ayarı '{privacy}' geçersiz; 'public' kullanılacak."
+                    )
+                    print(warn_msg, flush=True)
+                    _append_error("[upload warning] invalid YT_PRIVACY value: " + privacy)
+                    privacy = "public"
                 url = try_upload_youtube(
                     mp4_path,
                     title=title,


### PR DESCRIPTION
## Summary
- normalize the YT_PRIVACY environment variable before use
- warn and default to public when an unsupported privacy value is provided

## Testing
- python -m compileall src *(fails: SyntaxError already present in src/tts.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c88e0c4d408329b4aef85c8245ca97