### PR TITLE
Allow workflow to read YouTube credentials from repo variables

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -97,9 +97,9 @@ jobs:
 
           HF_TOKEN: ${{ secrets.HF_TOKEN != '' && secrets.HF_TOKEN || vars.HF_TOKEN }}
 
-          YT_CLIENT_ID: ${{ secrets.YT_CLIENT_ID }}
-          YT_CLIENT_SECRET: ${{ secrets.YT_CLIENT_SECRET }}
-          YT_REFRESH_TOKEN: ${{ secrets.YT_REFRESH_TOKEN }}
+          YT_CLIENT_ID: ${{ secrets.YT_CLIENT_ID != '' && secrets.YT_CLIENT_ID || vars.YT_CLIENT_ID }}
+          YT_CLIENT_SECRET: ${{ secrets.YT_CLIENT_SECRET != '' && secrets.YT_CLIENT_SECRET || vars.YT_CLIENT_SECRET }}
+          YT_REFRESH_TOKEN: ${{ secrets.YT_REFRESH_TOKEN != '' && secrets.YT_REFRESH_TOKEN || vars.YT_REFRESH_TOKEN }}
           YT_PRIVACY: "unlisted"   # önce liste dışı dene
           YT_MADE_FOR_KIDS: "false"
 


### PR DESCRIPTION
## Summary
- add repository variable fallbacks for YouTube OAuth credentials in the auto workflow

## Testing
- not run (workflow file change)


------
https://chatgpt.com/codex/tasks/task_e_68c8a0a9f34c8329afdcbc76fa2024cb