### PR TITLE
Set YouTube upload privacy to public

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -100,7 +100,7 @@ jobs:
           YT_CLIENT_ID: ${{ secrets.YT_CLIENT_ID != '' && secrets.YT_CLIENT_ID || vars.YT_CLIENT_ID }}
           YT_CLIENT_SECRET: ${{ secrets.YT_CLIENT_SECRET != '' && secrets.YT_CLIENT_SECRET || vars.YT_CLIENT_SECRET }}
           YT_REFRESH_TOKEN: ${{ secrets.YT_REFRESH_TOKEN != '' && secrets.YT_REFRESH_TOKEN || vars.YT_REFRESH_TOKEN }}
-          YT_PRIVACY: "unlisted"   # önce liste dışı dene
+          YT_PRIVACY: "public"   # varsayılan herkese açık
           YT_MADE_FOR_KIDS: "false"
 
           PYTHONIOENCODING: "utf-8"


### PR DESCRIPTION
## Summary
- update the auto workflow to set the YouTube upload privacy to public

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68c8b04a5b8c8329b48c9168ba91052a