### PR TITLE
Print YouTube error summary on upload failure

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -274,6 +274,7 @@ def main() -> None:
     except Exception as e:
         _append_error(f"[upload warning] {e}")
         print(f"[upload warning] {e}", flush=True)
+        _print_youtube_error_summary()
 
     # ÖNEMLİ: Asla sys.exit(1) yapma; loglara yazdık ve fallback ile çıktıyı ürettik.
     return


### PR DESCRIPTION
## Summary
- ensure the YouTube upload exception handler displays the parsed youtube_error.json summary

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8c3ec14f483299f072f2ad3ae6499