### PR TITLE
Gate YouTube channel export behind debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Optional:
 - `TTS_ATEMPO` (e.g. `1.07`)  
 - `BG_IMAGES_PER_SLIDE` (e.g. `5`)  
 - `PRESENTER_URL`, `PRESENTER_INITIALS`, `PRESENTER_POS`, `PRESENTER_SIZE`  
-- `BREAKING_ON`, `BREAKING_TEXT`  
+- `BREAKING_ON`, `BREAKING_TEXT`
+- `YT_DEBUG` → when `1/true`, saves channel metadata to `out/youtube_me.json` for troubleshooting; leave unset to avoid storing personal channel details.
 
 ## Run
 - Push to `main` or trigger **Actions → yt-auto → Run workflow**.


### PR DESCRIPTION
## Summary
- guard the channel introspection call behind a `YT_DEBUG` environment flag so we only persist metadata when debugging
- document the new flag so operators know how to enable/disable the export

## Testing
- python -m compileall src/youtube_upload.py

------
https://chatgpt.com/codex/tasks/task_e_68c8c6589da4832980ab8466c1641347