### PR TITLE
refactor: centralize environment helper

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
-import os
 import json
 import sys
 import time
@@ -8,6 +7,12 @@ import traceback
 import subprocess
 from pathlib import Path
 from typing import Optional, List, Any
+
+# Ortak yardımcılar
+try:  # pragma: no cover - doğrudan çalıştırma için
+    from .utils.env import _env
+except ImportError:  # pragma: no cover - fallback
+    from utils.env import _env  # type: ignore
 
 # Yerel modüller
 try:
@@ -41,10 +46,6 @@ make_slideshow_video = getattr(_video, "make_slideshow_video", None)
 try_upload_youtube   = getattr(_uploader, "try_upload_youtube", None)
 
 # ---------- Yardımcılar ----------
-def _env(name: str, default: Optional[str] = None) -> Optional[str]:
-    v = os.getenv(name)
-    return v if (v is not None and str(v).strip() != "") else default
-
 def _ts(fmt: str = "%Y%m%d-%H%M%S") -> str:
     return time.strftime(fmt, time.gmtime())
 

--- a/src/scriptgen.py
+++ b/src/scriptgen.py
@@ -34,10 +34,10 @@ except Exception:
 
 import xml.etree.ElementTree as ET
 
-
-def _env(name: str, default: Optional[str] = None) -> Optional[str]:
-    v = os.getenv(name)
-    return v if (v is not None and str(v).strip() != "") else default
+try:  # pragma: no cover - doğrudan çağırma desteği
+    from .utils.env import _env
+except ImportError:  # pragma: no cover - fallback
+    from utils.env import _env  # type: ignore
 
 def _fmt_usd(x: float) -> str:
     return f"${x:,.2f}"

--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -1,0 +1,15 @@
+"""Environment variable helpers used across the automation package."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+__all__ = ["_env"]
+
+
+def _env(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Return the stripped environment variable or ``default`` when empty."""
+    value = os.getenv(name)
+    if value is None or str(value).strip() == "":
+        return default
+    return value

--- a/src/video.py
+++ b/src/video.py
@@ -7,13 +7,14 @@ from typing import List, Tuple, Iterable, Optional
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
 import urllib.request
 
+try:  # pragma: no cover - doğrudan çağırma desteği
+    from .utils.env import _env
+except ImportError:  # pragma: no cover - fallback
+    from utils.env import _env  # type: ignore
+
 W, H = 1080, 1920
 FONT_BOLD = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
 FONT_REG  = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-
-def _env(name: str, default: str) -> str:
-    v = os.getenv(name)
-    return v if (v is not None and str(v).strip() != "") else default
 
 # ---- Ağ ve işlem zaman aşımları ----
 NET_TIMEOUT = float(_env("NET_TIMEOUT", "8"))       # saniye (tek indirme)

--- a/src/youtube_upload.py
+++ b/src/youtube_upload.py
@@ -10,13 +10,14 @@ from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 
+try:  # pragma: no cover - doğrudan çağırma desteği
+    from .utils.env import _env
+except ImportError:  # pragma: no cover - fallback
+    from utils.env import _env  # type: ignore
+
 SCOPES: List[str] = [
     "https://www.googleapis.com/auth/youtube.upload",
 ]
-
-def _env(name: str, default: Optional[str] = None) -> Optional[str]:
-    v = os.getenv(name)
-    return v if (v is not None and str(v).strip() != "") else default
 
 def _get_bool_env(name: str, default: bool=False) -> bool:
     v=_env(name)


### PR DESCRIPTION
## Summary
- add a shared `_env` helper module under `src/utils`
- update `main`, `scriptgen`, `video`, and `youtube_upload` to import the shared helper and remove duplicate implementations
- support running the modules directly by falling back to absolute imports when needed

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c8c65b7a8483299efd3f0e6d45554b