### PR TITLE
Add pytest regression tests for content generation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ Optional:
 - Outputs saved under `out/` and uploaded as artifacts.
 - Optional: set `YT_PRIVACY` to `public`, `unlisted`, or `private` before running the
   workflow to control the uploaded video's visibility (defaults to `public`).
+
+## Tests
+
+Install dependencies (including pytest) and run the suite:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ google-auth-oauthlib==1.2.1
 google-auth-httplib2==0.2.0
 pydub==0.25.1
 Pillow>=10
+
+pytest>=8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_scriptgen.py
+++ b/tests/test_scriptgen.py
@@ -1,0 +1,45 @@
+import scriptgen
+
+
+def test_generate_script_crypto_success(monkeypatch):
+    monkeypatch.setenv("LANGUAGE", "en")
+    monkeypatch.setenv("CRYPTO_COINS", "bitcoin,solana")
+
+    fake_data = {
+        "bitcoin": {"usd": 50000.0, "usd_24h_change": 1.5},
+        "solana": {"usd": 150.0, "usd_24h_change": -2.1},
+    }
+
+    def fake_fetch(ids):
+        # ensure generate_script forwards coin list from configuration
+        assert ids == ["bitcoin", "solana"]
+        return fake_data
+
+    monkeypatch.setattr(scriptgen, "fetch_crypto_simple", fake_fetch)
+
+    script, captions, coins_data = scriptgen.generate_script(mode="crypto")
+
+    assert "60-second crypto brief" in script
+    assert "BITCOIN" in script and "24h +1.50%" in script
+    assert captions == [
+        "BITCOIN: $50,000.00 | 24h +1.50%",
+        "SOLANA: $150.00 | 24h -2.10%",
+    ]
+    assert coins_data == fake_data
+
+
+def test_generate_script_crypto_fallback(monkeypatch):
+    monkeypatch.setenv("LANGUAGE", "en")
+    monkeypatch.setenv("CRYPTO_COINS", "bitcoin")
+
+    def fake_fetch(ids):
+        assert ids == ["bitcoin"]
+        return {}
+
+    monkeypatch.setattr(scriptgen, "fetch_crypto_simple", fake_fetch)
+
+    script, captions, coins_data = scriptgen.generate_script(mode="crypto")
+
+    assert "no data" in script.lower()
+    assert captions == ["60-second crypto brief (no data)"]
+    assert coins_data == {}

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+import tts
+
+
+def test_synth_tts_to_mp3_with_mocked_openai(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    recorded_segments = []
+
+    def fake_segment(text, voice, out_path):
+        recorded_segments.append((text, voice))
+        Path(out_path).write_bytes(f"SEG:{text}".encode("utf-8"))
+
+    monkeypatch.setattr(tts, "_openai_tts_segment", fake_segment)
+
+    def fake_silence(seconds):
+        silence_path = tmp_path / f"silence_{seconds:.2f}.mp3"
+        silence_path.write_bytes(b"SILENCE")
+        return silence_path.as_posix()
+
+    monkeypatch.setattr(tts, "_mk_silence_mp3", fake_silence)
+
+    ffmpeg_calls = []
+
+    def fake_run(cmd, check, stdout, stderr, **kwargs):
+        ffmpeg_calls.append(cmd)
+        out_file = Path(cmd[-1])
+        out_file.write_bytes(b"FINAL")
+        class Result:
+            pass
+        return Result()
+
+    monkeypatch.setattr(tts.subprocess, "run", fake_run)
+
+    out_mp3 = tmp_path / "narration.mp3"
+    script_text = "\n".join([
+        "[HOOK] Welcome to the show",
+        "[CUT] Here is the update",
+        "[CTA] See you soon",
+    ])
+
+    tts.synth_tts_to_mp3(
+        script_text,
+        out_mp3.as_posix(),
+        voice="test-voice",
+        atempo="1.25",
+        gap_ms=250,
+        bitrate="96k",
+    )
+
+    assert recorded_segments == [
+        ("Welcome to the show", "test-voice"),
+        ("Here is the update", "test-voice"),
+        ("See you soon", "test-voice"),
+    ]
+    assert ffmpeg_calls, "Expected ffmpeg to be invoked"
+    cmd = ffmpeg_calls[0]
+    assert cmd[0] == "ffmpeg"
+    assert "-af" in cmd
+    atempo_arg = cmd[cmd.index("-af") + 1]
+    assert "atempo" in atempo_arg
+    assert out_mp3.exists()
+    assert out_mp3.read_bytes() == b"FINAL"

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,99 @@
+import shutil
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+import video
+
+
+def test_make_slideshow_video_uses_downloads_and_ffmpeg(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    base_image = tmp_path / "base.jpg"
+    Image.new("RGB", (200, 200), color=(10, 120, 200)).save(base_image)
+
+    audio_mp3 = tmp_path / "audio.mp3"
+    audio_mp3.write_bytes(b"fake audio")
+
+    out_mp4 = tmp_path / "result.mp4"
+
+    monkeypatch.setenv("BG_IMAGES_PER_SLIDE", "1")
+    monkeypatch.setenv("FPS", "24")
+    monkeypatch.setenv("TTS_BITRATE", "96k")
+
+    def fake_ffprobe(path):
+        assert path == audio_mp3.as_posix()
+        return 9.0
+
+    monkeypatch.setattr(video, "_ffprobe_duration", fake_ffprobe)
+
+    def fake_bg_urls(theme, count, keywords=None, genre=None):
+        assert theme == "news"
+        assert count == 1
+        return ["https://example.com/bg.jpg"]
+
+    monkeypatch.setattr(video, "_bg_urls_for_theme", fake_bg_urls)
+
+    download_requests = []
+
+    def fake_download_many(urls):
+        download_requests.append(list(urls))
+        paths = []
+        for idx, _ in enumerate(urls):
+            tmp_img = tmp_path / f"dl_{idx}.jpg"
+            shutil.copy(base_image, tmp_img)
+            paths.append(tmp_img.as_posix())
+        return paths
+
+    monkeypatch.setattr(video, "_download_many", fake_download_many)
+
+    png_calls = []
+
+    def fake_png_to_video(png, duration, out_mp4_path, fps, zoom_per_sec):
+        png_calls.append((png, duration, out_mp4_path, fps, zoom_per_sec))
+        Path(out_mp4_path).write_text("video")
+
+    monkeypatch.setattr(video, "_png_to_video", fake_png_to_video)
+
+    concat_calls = []
+
+    def fake_concat(parts, out_mp4_path):
+        concat_calls.append((list(parts), out_mp4_path))
+        Path(out_mp4_path).write_text("concat")
+
+    monkeypatch.setattr(video, "_concat", fake_concat)
+
+    mux_calls = []
+
+    def fake_mux(video_mp4, audio_mp3_arg, final_out, bitrate):
+        mux_calls.append((video_mp4, audio_mp3_arg, final_out, bitrate))
+        Path(final_out).write_text("muxed")
+
+    monkeypatch.setattr(video, "_mux", fake_mux)
+
+    captions = ["Breaking update"]
+
+    video.make_slideshow_video(
+        images=[],
+        captions=captions,
+        audio_mp3=audio_mp3.as_posix(),
+        out_mp4=out_mp4.as_posix(),
+        theme="news",
+    )
+
+    assert download_requests == [["https://example.com/bg.jpg"]]
+    assert png_calls, "Slides should render backgrounds"
+    first_png_call = png_calls[0]
+    assert Path(first_png_call[0]).suffix == ".png"
+    assert pytest.approx(first_png_call[1], rel=1e-3) == 9.0
+    assert first_png_call[3] == 24
+
+    assert len(concat_calls) == 2
+    assert mux_calls == [
+        (concat_calls[-1][1], audio_mp3.as_posix(), out_mp4.as_posix(), "96k")
+    ]
+    assert out_mp4.exists()
+    assert out_mp4.read_text() == "muxed"
+
+    generated_pngs = list((tmp_path / "out").glob("*.png"))
+    assert generated_pngs, "Expected rendered slide images"


### PR DESCRIPTION
## Summary
- add pytest configuration to import modules from the src directory
- add coverage for generate_script, synth_tts_to_mp3, and make_slideshow_video using controlled fixtures
- document how to run the pytest suite and add pytest to the dependency list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8c65f3f448329af0b7b33ef15502e