### PR TITLE
Expand default YouTube scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   2. With that project selected, go to **APIs & Services → Library**, search for **YouTube Data API v3**, and press **Enable**.
   3. Open **APIs & Services → Credentials → Create Credentials → OAuth client ID**. If prompted, configure the OAuth consent screen (external, add the YouTube scopes below). Choose **Desktop App** as the application type and finish the wizard.
   4. Download the OAuth client JSON and copy the `client_id`/`client_secret` values into the repository/workflow secrets `YT_CLIENT_ID` and `YT_CLIENT_SECRET`.
-  5. Generate a refresh token using exactly the same scopes as the app uses. The required scopes (`YT_SCOPES` in the code) are:
+  5. Generate a refresh token using exactly the same scopes as the app uses. The defaults (`YT_SCOPES` in the code) request upload and read access:
      - `https://www.googleapis.com/auth/youtube.upload`
      - `https://www.googleapis.com/auth/youtube.readonly`
 

--- a/src/youtube_upload.py
+++ b/src/youtube_upload.py
@@ -18,8 +18,11 @@ def _get_bool_env(name: str, default: bool=False) -> bool:
     v=_env(name)
     return default if v is None else str(v).strip().lower() in ("1","true","yes","on")
 
+# Default scopes allow uploads and basic read access so we can fetch
+# channel metadata/status during debug checks.
 SCOPES: List[str] = [
     "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube.readonly",
 ]
 
 YT_DEBUG: bool = _get_bool_env("YT_DEBUG", False)


### PR DESCRIPTION
## Summary
- add the YouTube Data API read scope to the default OAuth scopes used by the uploader
- document that the default scope set now includes both upload and readonly permissions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8d13a11608329a5fa5147334dbe07