### PR TITLE
Refactor build_titles API

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -160,9 +160,25 @@ def main() -> None:
             "story":  "Story:",
         }.get(theme, "Daily Brief:"))
         if callable(build_titles):
-            title, description = build_titles(
-                theme, captions=captions, coins_data=coins_data, title_prefix=title_prefix
+            title_meta = build_titles(
+                theme,
+                captions=captions,
+                coins_data=coins_data,
+                title_prefix=title_prefix,
             )
+            if hasattr(title_meta, "as_tuple") and callable(getattr(title_meta, "as_tuple")):
+                title, description = title_meta.as_tuple()
+            elif isinstance(title_meta, tuple) and len(title_meta) >= 2:
+                title, description = title_meta[:2]
+            elif isinstance(title_meta, dict):
+                title = title_meta.get("title")
+                description = title_meta.get("description")
+            else:
+                title = getattr(title_meta, "title", None)
+                description = getattr(title_meta, "description", None)
+
+            if not isinstance(title, str) or not isinstance(description, str):
+                raise TypeError("build_titles beklenmedik çıktı")
         else:
             raise RuntimeError("build_titles fonksiyonu yok")
     except Exception as e:

--- a/tests/test_scriptgen.py
+++ b/tests/test_scriptgen.py
@@ -43,3 +43,38 @@ def test_generate_script_crypto_fallback(monkeypatch):
     assert "no data" in script.lower()
     assert captions == ["60-second crypto brief (no data)"]
     assert coins_data == {}
+
+
+def test_build_titles_returns_metadata_for_standard_use():
+    captions = ["Breaking headline", "Second story"]
+
+    meta = scriptgen.build_titles("news", captions=captions)
+
+    assert isinstance(meta, scriptgen.TitleMetadata)
+    assert meta.title.startswith("Daily Brief:")
+    assert meta.title.endswith("Breaking headline")
+    assert meta.captions == captions
+    assert meta.captions is not captions
+    assert "- Breaking headline" in (meta.description or "")
+
+
+def test_build_titles_coin_rows_returns_caption_metadata():
+    rows = [{"id": "bitcoin", "usd": 12345.0, "usd_24h_change": 2.5}]
+
+    meta = scriptgen.build_titles("crypto", coin_rows=rows)
+
+    assert isinstance(meta, scriptgen.TitleMetadata)
+    assert meta.title is None
+    assert meta.description is None
+    assert meta.captions == ["BITCOIN: $12,345.00 | 24h +2.50%"]
+
+
+def test_build_titles_headlines_returns_caption_metadata():
+    headlines = [("First highlight", "https://example.com"), ("Second highlight", "")]
+
+    meta = scriptgen.build_titles("news", headlines=headlines)
+
+    assert isinstance(meta, scriptgen.TitleMetadata)
+    assert meta.title is None
+    assert meta.description is None
+    assert meta.captions == ["First highlight", "Second highlight"]


### PR DESCRIPTION
## Summary
- introduce a `TitleMetadata` dataclass so `build_titles` returns a consistent structure
- update `build_titles` callers and ensure the module CLI prints the new metadata
- expand scriptgen tests to cover the new metadata-focused behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8df489cf08329a96c79e18d7ff6f8