### PR TITLE
Fix YouTube scopes parsing

### DIFF
--- a/src/youtube_upload.py
+++ b/src/youtube_upload.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 import os, json, mimetypes, pathlib, time
+import re
 from typing import Optional, List, Dict, Any
 
 from googleapiclient.discovery import build
@@ -31,7 +32,10 @@ def _configured_scopes() -> List[str]:
     raw = _env("YT_SCOPES")
     if raw is None:
         return SCOPES
-    scopes = [part.strip() for part in raw.split(",") if part.strip()]
+    # Allow comma or whitespace separated scopes so users can copy the same
+    # values they pass to the helper script (``--scopes scope1 scope2``).
+    tokens = re.split(r"[,\s]+", raw)
+    scopes = [part.strip() for part in tokens if part.strip()]
     return scopes or SCOPES
 
 def _dump_json(path: str, obj: Any) -> None:

--- a/tests/test_youtube_upload.py
+++ b/tests/test_youtube_upload.py
@@ -1,0 +1,25 @@
+import importlib
+
+import youtube_upload
+
+
+def test_configured_scopes_defaults_when_env_missing(monkeypatch):
+    monkeypatch.delenv("YT_SCOPES", raising=False)
+    module = importlib.reload(youtube_upload)
+    assert module._configured_scopes() == module.SCOPES
+
+
+def test_configured_scopes_parses_commas_and_whitespace(monkeypatch):
+    monkeypatch.setenv(
+        "YT_SCOPES",
+        "scope.one scope.two,scope.three\n https://example.com/custom",
+    )
+    # Reload to ensure module level caches don't interfere with env lookups.
+    module = importlib.reload(youtube_upload)
+    assert module._configured_scopes() == [
+        "scope.one",
+        "scope.two",
+        "scope.three",
+        "https://example.com/custom",
+    ]
+


### PR DESCRIPTION
## Summary
- allow YT_SCOPES to be provided as either comma- or whitespace-separated values
- add regression tests covering the parsing logic in youtube_upload._configured_scopes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9be31e61c8329a76dbb3126d15ac3