### PR TITLE
Fix running main.py as script to load local modules

### DIFF
--- a/tests/test_main_imports.py
+++ b/tests/test_main_imports.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+
+
+def test_main_imports_without_package(capsys):
+    target_modules = ["main", "scriptgen", "tts", "video", "youtube_upload"]
+    originals = {name: sys.modules.get(name) for name in target_modules}
+
+    for name in target_modules:
+        sys.modules.pop(name, None)
+
+    try:
+        module = importlib.import_module("main")
+
+        captured = capsys.readouterr().out
+        assert "[import warning]" not in captured
+
+        assert callable(module.generate_script)
+        assert callable(module.build_titles)
+        assert callable(module.synth_tts_to_mp3)
+        assert callable(module.make_slideshow_video)
+        assert callable(module.try_upload_youtube)
+    finally:
+        for name, mod in originals.items():
+            if mod is not None:
+                sys.modules[name] = mod
+            else:
+                sys.modules.pop(name, None)


### PR DESCRIPTION
## Summary
- add a helper in `src/main.py` to import sibling modules whether the entry point runs as a package or a script
- ensure the YouTube workflow functions remain available by exercising the new helper in a regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c9f155a1bc8329b6c980502135cfc7